### PR TITLE
feat: Add image upload to 'Our History' section

### DIFF
--- a/src/app/[locale]/about_us/page.tsx
+++ b/src/app/[locale]/about_us/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
 import { fetchAboutUsPageContent } from '../../../app/fetchContent';
 import { LocaleSpecificAboutUsContent } from '../../../app/types';
 
@@ -106,7 +107,18 @@ export default function AboutUsPage({ params }: { params: Promise<{ locale: stri
         boxShadow: 'var(--shadow)',
       }}>
         <h3>{content.history.title}</h3>
-        <p style={{ whiteSpace: 'pre-wrap' }}>{content.history.text}</p>
+        <div style={{ display: 'flex', flexDirection: 'row', gap: '2rem', alignItems: 'center' }}>
+          {content.history.imageUrl && (
+            <Image
+              src={content.history.imageUrl}
+              alt="Our History"
+              width={300}
+              height={300}
+              style={{ borderRadius: 'var(--border-radius)', objectFit: 'cover' }}
+            />
+          )}
+          <p style={{ whiteSpace: 'pre-wrap', flex: 1 }}>{content.history.text}</p>
+        </div>
       </section>
     </div>
   );

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -71,6 +71,7 @@ export interface FirestoreHomePageContent {
 export interface AboutUsSection {
   title: string;
   text: string;
+  imageUrl?: string;
 }
 
 export interface LocaleSpecificAboutUsContent {


### PR DESCRIPTION
This commit introduces the functionality to upload and display an image in the 'Our History' section of the 'About Us' page.

- Updated the `AboutUsSection` type to include an optional `imageUrl`.
- Modified the `ContentManagement` component to include an image upload form for the 'Our History' section in the admin panel.
- Updated the 'About Us' page to display the uploaded image in a flex row layout with the text.
- Replaced `<img>` tags with `next/image`'s `Image` component to improve performance and avoid warnings.