### PR TITLE
feat: Grant content-manager permission to upload media

### DIFF
--- a/functions/functions/src/media/index.js
+++ b/functions/functions/src/media/index.js
@@ -23,7 +23,7 @@ app.use((req, res, next) => {
 const authMiddleware = async (req, res, next) => {
     try {
         const { decodedToken } = await authenticate(req, res);
-        requireRole(decodedToken, ['admin', 'superadmin']);
+        requireRole(decodedToken, ['admin', 'superadmin', 'content-manager']);
         req.user = decodedToken;
         next();
     } catch (error) {

--- a/storage.rules
+++ b/storage.rules
@@ -19,7 +19,7 @@ service firebase.storage {
 
     // Allow authorized users to write to the new 'media' folder for the library.
     match /media/{allPaths=**} {
-      allow write: if request.auth != null && request.auth.token.role in ['admin', 'superadmin'];
+      allow write: if request.auth != null && request.auth.token.role in ['admin', 'superadmin', 'content-manager'];
     }
   }
 }


### PR DESCRIPTION
This change grants the 'content-manager' role the permission to upload images to the Media Library.

The following files were modified:
- `storage.rules`: Added 'content-manager' to the list of roles that can write to the '/media/' path.
- `functions/functions/src/media/index.js`: Added 'content-manager' to the `requireRole` check in the `authMiddleware` for the media API.